### PR TITLE
fix: msec/duration time calculations

### DIFF
--- a/bluray_info.c
+++ b/bluray_info.c
@@ -540,7 +540,7 @@ int main(int argc, char **argv) {
 			printf("   \"title\": %u,\n", json_ix);
 			printf("   \"playlist\": %" PRIu32 ",\n", bluray_title.playlist);
 			printf("   \"length\": \"%s\",\n", bluray_title.length);
-			printf("   \"msecs\": %" PRIu64 ",\n", bluray_title.duration / 900);
+			printf("   \"msecs\": %" PRIu64 ",\n", bluray_title.duration / 90);
 			printf("   \"angles\": %" PRIu8 ",\n", bluray_title.angles);
 			printf("   \"blocks\": %" PRIu64 ",\n", bluray_title.blocks);
 			printf("   \"filesize\": %" PRIu64 ",\n", bluray_title.size);
@@ -717,8 +717,8 @@ int main(int argc, char **argv) {
 					printf("     \"chapter\": %" PRIu32 ",\n", chapter_number);
 					printf("     \"start time\": \"%s\",\n", bluray_chapter.start_time);
 					printf("     \"length\": \"%s\",\n", bluray_chapter.length);
-					printf("     \"start\": %" PRIu64 ",\n", bluray_chapter.start / 900);
-					printf("     \"duration\": %" PRIu64 ",\n", bd_chapter->duration / 900);
+					printf("     \"start\": %" PRIu64 ",\n", bluray_chapter.start / 90);
+					printf("     \"duration\": %" PRIu64 ",\n", bd_chapter->duration / 90);
 					printf("     \"blocks\": %" PRIu64 ",\n", bluray_chapter.blocks);
 					printf("     \"filesize\": %" PRIu64 "\n", bluray_chapter.size);
 					if(chapter_number < bluray_title.chapters)


### PR DESCRIPTION
Hi, just a small bug I've been thinking was my fault but finally realized was from the JSON output of bluray_info. Currently, the "human formatted" time strings (like in the non-JSON output, `title.length`, and `chapter.start time`) are correct, but the millisecond values (`title.msecs`, `chapter.start`, `chapter.duration`) are 10x too small because of a division error.

These are the only locations where I know this bug exists for sure. There is another location in [bluray_time.c](https://github.com/beandog/bluray_info/blob/9165cbb1508fc4c40f99aa67dd6face071ce0d95/bluray_time.c#L22-L27) where there might be a similar issue, but I haven't tested bluray_time.